### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ An Op to simplify incident management.
 
 ## Requirements
 
-To run this or any other Op, install the [Ops Platform](https//cto.ai/platform).
+To run this or any other Op, install the [Ops Platform](https://cto.ai/platform).
 
-Find information about how to run and build Ops via the [Ops Platform Documentation](https//cto.ai/docs/overview).
+Find information about how to run and build Ops via the [Ops Platform Documentation](https://cto.ai/docs/overview).
 
 This Op requires credentials based on which services you integrate with:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Find information about how to run and build Ops via the [Ops Platform Documentat
 
 This Op requires credentials based on which services you integrate with:
 
-- **GitLab Access Token -** [Creating GitHub Personal Access Tokens](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
+- **GitLab Access Token -** [Creating GitLab Personal Access Tokens](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 - **PagerDuty API key -** [Getting PagerDuty API Key](https://support.pagerduty.com/docs/generating-api-keys)
 - **Slack WebHook URL -** [Adding Slack Webhooks Guide](https://slack.com/intl/en-ca/help/articles/115005265063-Incoming-WebHooks-for-Slack)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Find information about how to run and build Ops via the [Ops Platform Documentat
 
 This Op requires credentials based on which services you integrate with:
 
-- **Gitlab Access Token -** [Creating Github Personal Access Tokens](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
+- **GitLab Access Token -** [Creating GitHub Personal Access Tokens](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line)
 - **PagerDuty API key -** [Getting PagerDuty API Key](https://support.pagerduty.com/docs/generating-api-keys)
 - **Slack WebHook URL -** [Adding Slack Webhooks Guide](https://slack.com/intl/en-ca/help/articles/115005265063-Incoming-WebHooks-for-Slack)
 

--- a/prompts/index.js
+++ b/prompts/index.js
@@ -7,14 +7,14 @@ const newRunPrompts = [
   {
     type: 'input',
     name: 'gitlabToken',
-    message: `Please input your Gitlab Access Token ${reset.green(
+    message: `Please input your GitLab Access Token ${reset.green(
      '→',
     )}`,
   },
   {
     type: 'input',
     name: 'projectId',
-    message: `Please input your Gitlab Project Id ${reset.green(
+    message: `Please input your GitLab Project Id ${reset.green(
      '→',
     )}`,
   },
@@ -38,7 +38,7 @@ const useOldAuthPrompt = [
   {
     type: 'confirm',
     name: 'useOld',
-    message: `Would you like to use your previously entered Gitlab, Slack, and PagerDuty configuration? ${reset.green(
+    message: `Would you like to use your previously entered GitLab, Slack, and PagerDuty configuration? ${reset.green(
      '→',
     )}`,
   },


### PR DESCRIPTION
### Changes

- Fix link in readme
- Fix typo: `Gitlab` -> `GitLab`, `Github` -> `GitLab`
- Correct GitLab Access Token documentation link